### PR TITLE
(feat): Clean dist folder to prevent out-of-date code from being tested

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,6 +26,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.nvmrc.outputs.node-version }}"
+      - id: clean-dist
+        shell: bash
+        run: |
+          # Clean the existing dist/ folder so that we only test fresh
+          # compiled code
+          rm -rf dist/
       - run: |
           npm ci
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,19 +35,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.nvmrc.outputs.node-version }}"
+      - id: clean-dist
+        shell: bash
+        run: |
+          # Clean the existing dist/ folder so that we only release fresh
+          # compiled code
+          rm -rf dist/
       - run: |
           npm ci
       - run: |
           npm run all
-        # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
-      - name: Compare the Expected and Actual dist/ Directories
-        run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
-            git diff
-            exit 1
-          fi
-        id: diff
       - name: Perform Release
         run: |
           npm run release -- \


### PR DESCRIPTION
I personally find that the `dist` folder can be hard to manage as there is a high change that we accidentally release code that might be out of date. So I propose to solve this by nuking the `dist` folder during build and release