### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dispatch-workflow",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dispatch-workflow",
-      "version": "1.7.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispatch-workflow",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "private": true,
   "description": "A GitHub action to dispatch a remote GitHub workflow and optionally retrieve its information",
   "main": "lib/index.js",


### PR DESCRIPTION
Manually creating Release 2.0.0 for `lasith-kg/dispatch-workflow`. Currently `release-it` does not support Node 20. This is the reason we are performing our major change in the first place. For now, I will try my best to create an equivalent release